### PR TITLE
fix(p_loraks.py): remove incorrect S-matrix operator_shape doubling i…

### DIFF
--- a/pymritools/recon/loraks/p_loraks.py
+++ b/pymritools/recon/loraks/p_loraks.py
@@ -297,8 +297,6 @@ class PLoraks(LoraksBase):
             self.patch_shape,
             self.sample_directions
         )
-        if self.operator_type == OperatorType.S:
-            self.matrix_operator_shape = tuple(2 * d for d in self.matrix_operator_shape)
 
     def _get_operator_matrix_size(self) -> tuple[int, int]:
         """


### PR DESCRIPTION
## Pull Request Description

### Problem

When using P-LORAKS with the S-matrix operator type and multi-coil data, reconstruction failed with the error:

```
RuntimeError: shape '[125000, 98]' is invalid for input of size 3062500
```

This occurred in `s_operator()` at the line `indices_rev = indices.view(matrix_shape).flip(dims=(0,))`.

### Root Cause Analysis

**Complete data-flow trace through the S-matrix pipeline:**

| Step | Object | Elements | Shape |
|------|--------|----------|-------|
| 1. `get_linear_indices()` returns | `indices` | 3,062,500 | `(62500, 49)` = `(ns, nb)` |
| 2. `_initialize_matrix_indices()` **incorrectly doubles** | `matrix_operator_shape` | — | `(125000, 98)` = `(2×ns, 2×nb)` |
| 3. `s_operator()` calls `indices.view(matrix_shape)` | `indices` | 3,062,500 | → needs 12,250,000 ❌ |

The `s_operator` function internally handles S-matrix doubling via quadrant concatenation:

```python
s_u = concatenate([(s_p - s_m).real, -(s_p - s_m).imag], dim=1)
s_d = concatenate([(s_p + s_m).imag, (s_p + s_m).real], dim=1)
s  = concatenate([s_u, s_d], dim=-1)
# Final: [..., 2×nb, 2×ns] → correct S-matrix size
```

No external doubling of `matrix_operator_shape` is needed — the doubling inside `s_operator` already produces the correct `(2×nb, 2×ns)` dimensions.

### Fix

**File:** [p_loraks.py](file:///opt/data/private/projects/workspaces/KspaceMRI/PyMRItools/pymritools/recon/loraks/p_loraks.py#L294-L301)

Removed the 2 lines that incorrectly doubled `matrix_operator_shape` for S-matrix:

```diff
 def _initialize_matrix_indices(self):
     self.indices, self.matrix_operator_shape = get_linear_indices(
         self.k_space_shape[1:],
         self.patch_shape,
         self.sample_directions
     )
-    if self.operator_type == OperatorType.S:
-        self.matrix_operator_shape = tuple(2 * d for d in self.matrix_operator_shape)
```
